### PR TITLE
Only update brightness if it's changed

### DIFF
--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -58,13 +58,6 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
       #else
         brightness_slider.set_value (iscreen.brightness);
       #endif
-
-      // this fixes the first slow response
-      #if OLD_GSD
-        iscreen.set_percentage (iscreen.get_percentage ());
-      #else
-        iscreen.brightness = iscreen.brightness;
-      #endif
     }
 
     private async void init_bus () {
@@ -79,9 +72,13 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
         int val = (int) brightness_slider.get_value ();
         try {
           #if OLD_GSD
-            iscreen.set_percentage (val);
+            if (iscreen.get_percentage () != val) {
+                iscreen.set_percentage (val);
+            }
           #else
-            iscreen.brightness = val;
+            if (iscreen.brightness != val) {
+                iscreen.brightness = val;
+            }
           #endif
         } catch (IOError e) {
             warning ("screen brightness error %s", e.message);


### PR DESCRIPTION
Fixes #21 

Seems there's a bug somewhere upstream of this where if you set the brightness to the same value it's already at, you end up with `brightness = brightness - 1`.

I've removed aspects of the code that were setting the brightness to the same value it was already at, but it would be good to hear from @xwing7 about lines 61-67 that "fix the first slow response". I can't tell any difference after removing them, so it would be good to know the original reason for them.