### PR TITLE
Fix brightness mouse scrolling increment

### DIFF
--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -35,6 +35,7 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
         attach (image, 0, 0, 1, 1);
 
         brightness_slider = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 100, 10);
+        brightness_slider.adjustment.page_increment = 10;
         brightness_slider.margin_end = 12;
         brightness_slider.hexpand = true;
         brightness_slider.draw_value = false;


### PR DESCRIPTION
That should fix https://github.com/elementary/wingpanel-indicator-power/issues/30.

For me issue was only when scrolling with mouse - it was using page increment which was set to 100%. Now both increments are 10%.