### PR TITLE
Fix #13 Multi Battery by using the Upower display device for the panel

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -24,7 +24,7 @@ public class Power.Indicator : Wingpanel.Indicator {
 
     private Widgets.PopoverWidget? popover_widget = null;
 
-    private Services.Device primary_battery;
+    private Services.Device display_device;
     private bool notify_battery = false;
 
     public Indicator (bool is_in_session) {
@@ -80,43 +80,43 @@ public class Power.Indicator : Wingpanel.Indicator {
         
         if (visible) {
             if (dm.has_battery) {
-                update_primary_battery ();
+                update_display_device ();
                 if (!notify_battery) {
-                    dm.notify["primary-battery"].connect (update_primary_battery);
+                    dm.notify["display-device"].connect (update_display_device);
                     notify_battery = true;
                 }
             } else {
                 show_backlight_data ();
                 if (notify_battery) {
-                    dm.notify["primary-battery"].disconnect (update_primary_battery);
+                    dm.notify["display-device"].disconnect (update_display_device);
                     notify_battery = false;
                 }
             }
         }
     }
 
-    private void update_primary_battery () {
-        if (primary_battery != null) {
-            primary_battery.properties_updated.disconnect (show_primary_battery_data);
+    private void update_display_device () {
+       if (display_device != null) {
+            display_device.properties_updated.disconnect (show_display_device_data);
         }
 
-        primary_battery = Services.DeviceManager.get_default ().primary_battery;
-        if (primary_battery != null) {
-            show_primary_battery_data ();
-            primary_battery.properties_updated.connect (show_primary_battery_data);
+        display_device = Services.DeviceManager.get_default ().display_device;
+        if (display_device != null) {
+            show_display_device_data ();
+            display_device.properties_updated.connect (show_display_device_data);
         }
     }
 
-    private void show_primary_battery_data () {
-        if (primary_battery != null && display_widget != null) {
-            var icon_name = Utils.get_symbolic_icon_name_for_battery (primary_battery);
+    private void show_display_device_data () {
+        if (display_device != null && display_widget != null) {
+            var icon_name = Utils.get_symbolic_icon_name_for_battery (display_device);
             
             display_widget.set_icon_name (icon_name, true);
 
             /* Debug output for designers */
             debug ("Icon changed to \"%s\"", icon_name);
 
-            display_widget.set_percent ((int)Math.round (primary_battery.percentage));
+            display_widget.set_percent ((int)Math.round (display_device.percentage));
         }
     }
 

--- a/src/Services/DBusInterfaces/UPower.vala
+++ b/src/Services/DBusInterfaces/UPower.vala
@@ -21,6 +21,7 @@ namespace Power.Services.DBusInterfaces {
     [DBus (name = "org.freedesktop.UPower")]
     public interface UPower : Object {
         public abstract ObjectPath[] EnumerateDevices () throws IOError;
+        public abstract ObjectPath GetDisplayDevice () throws IOError;
 
         public signal void DeviceAdded (ObjectPath device_path);
         public signal void DeviceRemoved (ObjectPath device_path);


### PR DESCRIPTION
Basically we've been doing this wrong and we should use the display device of Upower to display out panel status. Tested together with my Bluetooth mouse and it does not seem to influence it.

Expected behaviour:
- [x] Upower will calculate an absolute Percentage by each batteries capacity
- [x] External devices like Bluetooth devices do not count toward the percentage
- [x] Devices in Popover are not affected, each battery is listed

I can't test some of the use cases above and need some help from people with multiple batteries to confirm everything works as expected.
