### PR TITLE
Add support for tablets (and some other devices)

### DIFF
--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -42,6 +42,9 @@ const uint32 DEVICE_TYPE_MOUSE = 5;
 const uint32 DEVICE_TYPE_KEYBOARD = 6;
 const uint32 DEVICE_TYPE_PDA = 7;
 const uint32 DEVICE_TYPE_PHONE = 8;
+const uint32 DEVICE_TYPE_MEDIA_PLAYER = 9;
+const uint32 DEVICE_TYPE_TABLET = 10;
+const uint32 DEVICE_TYPE_COMPUTER = 11;
 
 public class Power.Services.Device : Object {
     private const string DEVICE_INTERFACE = "org.freedesktop.UPower";

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -23,7 +23,10 @@ namespace Power.Utils {
     }
 
     public bool type_has_device_icon (uint32 device_type) {
-        return device_type == DEVICE_TYPE_PHONE || device_type == DEVICE_TYPE_MOUSE || device_type == DEVICE_TYPE_KEYBOARD;
+        return device_type == DEVICE_TYPE_PHONE ||
+               device_type == DEVICE_TYPE_MOUSE ||
+               device_type == DEVICE_TYPE_KEYBOARD ||
+               device_type == DEVICE_TYPE_TABLET;
     }
 
     public string get_symbolic_icon_name_for_battery (Services.Device battery) {
@@ -48,6 +51,7 @@ namespace Power.Utils {
             case DEVICE_TYPE_PHONE: return "phone";
             case DEVICE_TYPE_MOUSE: return "input-mouse";
             case DEVICE_TYPE_KEYBOARD: return "input-keyboard";
+            case DEVICE_TYPE_TABLET: return "input-tablet";
             default: return get_icon_name_for_battery (device);
         }
     }
@@ -92,10 +96,17 @@ namespace Power.Utils {
             case DEVICE_TYPE_KEYBOARD: title = _("Keyboard"); break;
             case DEVICE_TYPE_PDA: title = _("PDA"); break;
             case DEVICE_TYPE_PHONE: title = _("Phone"); break;
+            case DEVICE_TYPE_MEDIA_PLAYER: title = _("Media Player"); break;
+            case DEVICE_TYPE_TABLET: title = _("Tablet"); break;
+            case DEVICE_TYPE_COMPUTER: title = _("Computer"); break;
             default: title = battery.vendor + " " + _("Device"); break;
         }
 
         if (battery.device_type == DEVICE_TYPE_PHONE && battery.model != "") {
+            title = battery.model;
+        }
+
+        if (battery.device_type == DEVICE_TYPE_TABLET && battery.model != "") {
             title = battery.model;
         }
 


### PR DESCRIPTION
Show a badged tablet icon and the model name of the tablet (if it has one), rather than just a generic picture of battery with "Device" written next to it.

Before:
<img src="https://user-images.githubusercontent.com/3372394/41678211-5e4e4c9a-74c2-11e8-991e-ebe2e26850d7.png" width=200>

After:
<img src="https://user-images.githubusercontent.com/3372394/41678230-6b8cd5ca-74c2-11e8-949e-ae8fc25df1cb.png" width=200>

Also adds a couple more strings for some other device types that UPower supports.