### PR TITLE
PopoverWidget: simplify open settings

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -55,7 +55,6 @@ public class Power.Indicator : Wingpanel.Indicator {
     public override Gtk.Widget? get_widget () {
         if (popover_widget == null) {
             popover_widget = new Widgets.PopoverWidget (is_in_session);
-            popover_widget.settings_shown.connect (() => this.close ());
         }
 
         return popover_widget;

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -27,8 +27,6 @@ public class Power.Widgets.PopoverWidget : Gtk.Box {
 
     private Wingpanel.Widgets.Switch show_percent_switch;
 
-    public signal void settings_shown ();
-
     public PopoverWidget (bool is_in_session) {
         Object (is_in_session: is_in_session, orientation: Gtk.Orientation.VERTICAL);
     }
@@ -110,22 +108,18 @@ public class Power.Widgets.PopoverWidget : Gtk.Box {
 
         settings.bind ("show-percentage", show_percent_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
 
-        show_settings_button.clicked.connect (show_settings);
+        show_settings_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("settings://power", null);
+            } catch (Error e) {
+                warning ("Failed to open power settings: %s", e.message);
+            }
+        });
     }
 
     public void slim_down () {
         if (is_in_session) {
             app_list.clear_list ();
         }
-    }
-
-    private void show_settings () {
-        try {
-            AppInfo.launch_default_for_uri ("settings://power", null);
-        } catch (Error e) {
-            warning ("Failed to open power settings: %s", e.message);
-        }
-
-        settings_shown ();
     }
 }


### PR DESCRIPTION
Turn a single-use method into a lambda.
ModelButton closes the popover automatically so we don't need to do it ourselves