### PR TITLE
PopoverWidget: Rewrite as Gtk.Grid with revealers

### DIFF
--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -17,36 +17,37 @@
  * Boston, MA 02110-1301, USA.
  */
 
-public class Power.Widgets.PopoverWidget : Gtk.Box {
+public class Power.Widgets.PopoverWidget : Gtk.Grid {
     public bool is_in_session { get; construct; default = false; }
-    private DeviceList device_list;
-    private Wingpanel.Widgets.Separator device_separator = null;
-    private ScreenBrightness? screen_brightness;
+
+    private static Services.DeviceManager dm;
+
     private AppList app_list;
-    private Wingpanel.Widgets.Separator last_separator = null;
+    private Gtk.Revealer device_separator_revealer;
+    private Gtk.Revealer last_separator_revealer;
 
     public PopoverWidget (bool is_in_session) {
-        Object (is_in_session: is_in_session, orientation: Gtk.Orientation.VERTICAL);
+        Object (is_in_session: is_in_session);
+    }
+
+    static construct {
+        dm = Services.DeviceManager.get_default ();
     }
 
     construct {
-        var dm = Services.DeviceManager.get_default ();
         var settings = new GLib.Settings ("io.elementary.desktop.wingpanel.power");
 
-        device_list = new DeviceList ();
-        //debug ("show list of batteries");
-        pack_start (device_list);
+        var device_list = new DeviceList ();
 
-        if (dm.backlight.present) {
-            if (dm.has_battery) {
-                device_separator = new Wingpanel.Widgets.Separator ();
-                pack_start (device_separator);
-            }
+        var device_separator = new Wingpanel.Widgets.Separator ();
 
-            debug ("show brightness slider");
-            screen_brightness = new ScreenBrightness ();
-            pack_start (screen_brightness);
-        }
+        device_separator_revealer = new Gtk.Revealer ();
+        device_separator_revealer.add (device_separator);
+
+        var last_separator = new Wingpanel.Widgets.Separator ();
+
+        last_separator_revealer = new Gtk.Revealer ();
+        last_separator_revealer.add (last_separator);
 
         var show_percent_switch = new Wingpanel.Widgets.Switch (_("Show Percentage"), settings.get_boolean ("show-percentage"));
 
@@ -56,48 +57,29 @@ public class Power.Widgets.PopoverWidget : Gtk.Box {
         var show_settings_button = new Gtk.ModelButton ();
         show_settings_button.text = _("Power Settings…");
 
+        attach (device_list, 0, 0);
+        attach (device_separator_revealer, 0, 1);
+
+        if (dm.backlight.present) {
+            var screen_brightness = new ScreenBrightness ();
+            attach (screen_brightness, 0, 2);
+        }
+
+        attach (last_separator_revealer, 0, 4);
+        attach (show_percent_revealer, 0, 5);
+
         if (is_in_session) {
             app_list = new AppList ();
-            this.pack_start (app_list); /* The app-list contains an own separator that is displayed if necessary. */
+            attach (app_list, 0, 3); /* The app-list contains an own separator that is displayed if necessary. */
+            attach (show_settings_button, 0, 6);
         }
 
-        if (is_in_session || dm.has_battery) {
-            last_separator = new Wingpanel.Widgets.Separator ();
-            this.pack_start (last_separator);
-            add (show_percent_revealer);
-            if (is_in_session) {
-                this.pack_end (show_settings_button);
-            }
-        }
+        update_device_seperator_revealer ();
+        update_last_seperator_revealer ();
 
         dm.notify["has-battery"].connect((s, p) => {
-            bool had_separator = last_separator != null;
-            bool has_separator = is_in_session || dm.has_battery;
-
-            if (has_separator != had_separator) {
-                if (has_separator) {
-                    this.pack_start (last_separator = new Wingpanel.Widgets.Separator ());
-                    last_separator.show ();
-                } else {
-                    this.remove (last_separator);
-                    last_separator = null;
-                }
-            }
-
-            if (dm.backlight.present) {
-                bool had_battery = device_separator != null;
-                if (dm.has_battery != had_battery) {
-                    if (dm.has_battery) {
-                        device_separator = new Wingpanel.Widgets.Separator ();
-                        this.pack_start (device_separator);
-                        this.reorder_child (device_separator, 1);
-                        device_separator.show ();
-                    } else {
-                        this.remove (device_separator);
-                        device_separator = null;
-                    }
-                }
-            }
+            update_device_seperator_revealer ();
+            update_last_seperator_revealer ();
         });
 
         settings.bind ("show-percentage", show_percent_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
@@ -111,6 +93,14 @@ public class Power.Widgets.PopoverWidget : Gtk.Box {
                 warning ("Failed to open power settings: %s", e.message);
             }
         });
+    }
+
+    private void update_device_seperator_revealer () {
+        device_separator_revealer.reveal_child = dm.backlight.present && dm.has_battery;
+    }
+
+    private void update_last_seperator_revealer () {
+        last_separator_revealer.reveal_child = is_in_session || dm.has_battery;
     }
 
     public void slim_down () {


### PR DESCRIPTION
* Use Gtk.Grid so we can specify ordering
* Use Revealers instead of creating and destroying widgets

Should make it a lot clearer what the conditions are for showing and hiding elements and what their order should be