### PR TITLE
 build: fix install path for wingpanel indicator

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,4 +1,4 @@
 install_data(
     'io.elementary.desktop.wingpanel.power.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )

--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,12 @@ project(
 gettext_name = meson.project_name() + '-indicator'
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
-add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')], 
+add_project_arguments(['--vapidir', join_paths(meson.current_source_dir(), 'vapi')],
                       language: 'vala')
 
 subdir('data')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,5 @@
 wingpanel_dep = dependency('wingpanel-2.0')
+wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
 
 conf_data = configuration_data()
 conf_data.set('GETTEXT_PACKAGE', gettext_name)
@@ -47,5 +48,5 @@ shared_module(
     config_in,
     dependencies: dependencies,
     install: true,
-    install_dir : wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
+    install_dir : wingpanel_indicatorsdir
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this wingpanel_dep.get_pkgconfig_variable will return a
path from within wingpanel's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.