### PR TITLE
Fix terminal warnings

### DIFF
--- a/src/Services/ProcessMonitor/Monitor.vala
+++ b/src/Services/ProcessMonitor/Monitor.vala
@@ -19,7 +19,7 @@
 
 public class Power.Services.ProcessMonitor.Monitor : Object {
     public double cpu_load { get; private set; }
-    public double[] cpu_loads { get; private set; }
+    private double[] cpu_loads;
 
     uint64 cpu_last_used = 0;
     uint64 cpu_last_total = 0;
@@ -56,6 +56,11 @@ public class Power.Services.ProcessMonitor.Monitor : Object {
 
             return false;
         });
+    }
+
+    // This not appear to be used within elementaryos - can be removed?
+    public unowned double[] get_cpu_loads () {
+        return cpu_loads;
     }
 
     public static Monitor get_default () {

--- a/src/Services/ProcessMonitor/Monitor.vala
+++ b/src/Services/ProcessMonitor/Monitor.vala
@@ -58,11 +58,6 @@ public class Power.Services.ProcessMonitor.Monitor : Object {
         });
     }
 
-    // This not appear to be used within elementaryos - can be removed?
-    public unowned double[] get_cpu_loads () {
-        return cpu_loads;
-    }
-
     public static Monitor get_default () {
         if (instance == null) {
             instance = new Monitor ();

--- a/src/Widgets/DeviceRow.vala
+++ b/src/Widgets/DeviceRow.vala
@@ -191,4 +191,3 @@ public class Power.Widgets.DeviceRow : Gtk.ListBoxRow {
         }
     }
 }
-

--- a/src/Widgets/DeviceRow.vala
+++ b/src/Widgets/DeviceRow.vala
@@ -192,14 +192,3 @@ public class Power.Widgets.DeviceRow : Gtk.ListBoxRow {
     }
 }
 
-// TODO: Replace this and above with P_ when https://bugzilla.gnome.org/show_bug.cgi?id=758000 is fixed.
-private void translations () {
-    ngettext ("%lld day until full", "%lld days until full", 0);
-    ngettext ("%lld hour until full", "%lld hours until full", 0);
-    ngettext ("%lld minute until full", "%lld minutes until full", 0);
-    ngettext ("%lld second until full", "%lld seconds until full", 0);
-    ngettext ("%lld day until empty", "%lld days until empty", 0);
-    ngettext ("%lld hour until empty", "%lld hours until empty", 0);
-    ngettext ("%lld minute until empty", "%lld minutes until empty", 0);
-    ngettext ("%lld second until empty", "%lld seconds until empty", 0);
-}

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -42,7 +42,7 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
             on_scale_value_changed.begin ();
         });
 
-        (iscreen as DBusProxy).g_properties_changed.connect (on_screen_properties_changed);
+        ((DBusProxy)iscreen).g_properties_changed.connect (on_screen_properties_changed);
 
         brightness_slider.set_value (iscreen.brightness);
 
@@ -76,12 +76,8 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
 
     private async void on_scale_value_changed () {
         int val = (int) brightness_slider.get_value ();
-        try {
-            if (iscreen.brightness != val) {
-                iscreen.brightness = val;
-            }
-        } catch (IOError e) {
-            warning ("screen brightness error %s", e.message);
+        if (iscreen.brightness != val) {
+            iscreen.brightness = val;
         }
     }
 }


### PR DESCRIPTION
* ProcessMonitor.vala: Array cannot be property
* DeviceRow.vala: Remove unused function
* ScreenBrightness.vala: Unsafe cast; Unneeded try/catch