### PR TITLE
Filter out weird devices

### DIFF
--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -96,7 +96,7 @@ public class Power.Services.DeviceManager : Object {
             var devices = upower.enumerate_devices ();
 
             foreach (ObjectPath device_path in devices) {
-                if (determine_attached_device(device_path) == true) {
+                if (determine_attached_device (device_path) == true) {
                     register_device (device_path);
                 }
             }

--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -74,6 +74,18 @@ public class Power.Services.DeviceManager : Object {
         }
     }
 
+    private bool determine_attached_device (ObjectPath device_path) {
+        var device = new Device (device_path);
+
+        // this prevents from showing weird devices to show up.
+        // such as a laptops track pad pointer to show up as wacom tablet with no battery.
+        if ((device.technology == Device.Technology.UNKNOWN) &&
+            (device.state == Device.State.UNKNOWN)) {
+            return false;
+        }
+        return true;
+    }
+
     public void read_devices () {
         try {
             // Add Display Device for Panel display
@@ -84,7 +96,9 @@ public class Power.Services.DeviceManager : Object {
             var devices = upower.enumerate_devices ();
 
             foreach (ObjectPath device_path in devices) {
-                register_device (device_path);
+                if (determine_attached_device(device_path) == true) {
+                    register_device (device_path);
+                }
             }
         } catch (Error e) {
             critical ("Reading UPower devices failed: %s", e.message);


### PR DESCRIPTION
I have a laptop (Dell XPS 15 9750) which has a wacom HID build in track pad. I discovered that the power indicator was showing this device as a battery operated device. At the time i didn't do anything hoping some one else would notice.

![Screenshot from 2020-11-20 14-29-46@2x](https://user-images.githubusercontent.com/4341214/99805516-f9911880-2b3c-11eb-8be6-4726aefcfbb3.png)

But lately is has become annoying to see which made me look into what this is.  Upower service registered the wacom track pad.
Here is some information:
```
kay@kay-XPS-15-9570:~$ upower -i /org/freedesktop/UPower/devices/tablet_wacom_battery_0
  native-path:          wacom_battery_0
  model:                Wacom HID 488F
  power supply:         no
  updated:              Fri 20 Nov 2020 01:58:45 PM CET (27 seconds ago)
  has history:          yes
  has statistics:       yes
  tablet
    warning-level:       none
    percentage:          0%
    icon-name:          'battery-missing-symbolic'
```

```
kay@kay-XPS-15-9570:~$ upower -e
/org/freedesktop/UPower/devices/line_power_AC
/org/freedesktop/UPower/devices/battery_BAT0
/org/freedesktop/UPower/devices/tablet_wacom_battery_0
/org/freedesktop/UPower/devices/DisplayDevice
```
From the information here above it thinks it is a wacom tablet, but it is not. Then i did some digging into the Upower service and noticed that the device is registered under certain conditions.

(D-Feet screenshot of the properties)
![Screenshot from 2020-11-20 14-33-22@2x](https://user-images.githubusercontent.com/4341214/99805874-6a383500-2b3d-11eb-8bfa-f8697cad40fc.png)


With this change it will look like this:
![Screenshot from 2020-11-20 14-36-27@2x](https://user-images.githubusercontent.com/4341214/99806151-da46bb00-2b3d-11eb-8c5c-bb44257bda5e.png)


Let me know if anything needs changing, I am willingly to adjust the code and filter method. As long as the weird devices no longer show up. :wink: 