### PR TITLE
Use async version of Bus.get_proxy

### DIFF
--- a/src/Services/DBusInterfaces/UPower.vala
+++ b/src/Services/DBusInterfaces/UPower.vala
@@ -19,7 +19,9 @@
 
 namespace Power.Services.DBusInterfaces {
     [DBus (name = "org.freedesktop.UPower")]
-    public interface UPower : Object {
+    public interface UPower : GLib.DBusProxy {
+        public abstract bool on_battery { get; }
+
         public abstract ObjectPath[] enumerate_devices () throws GLib.Error;
         public abstract ObjectPath get_display_device () throws GLib.Error;
 


### PR DESCRIPTION
Since this DBus proxy gets constructed when the indicator is constructed, not when the widget is opened, it's best if we use async calls where possible.