### PR TITLE
Add switch to inhibit automatic standby

### DIFF
--- a/src/Helpers/Inhibitor.vala
+++ b/src/Helpers/Inhibitor.vala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+[DBus (name = "org.freedesktop.ScreenSaver")]
+public interface ScreenSaverIface : Object {
+    public abstract uint32 inhibit (string app_name, string reason) throws Error;
+    public abstract void un_inhibit (uint32 cookie) throws Error;
+    public abstract void simulate_user_activity () throws Error;
+}
+
+public class Inhibitor : Object {
+    private const string IFACE = "org.freedesktop.ScreenSaver";
+    private const string IFACE_PATH = "/ScreenSaver";
+
+    private static Inhibitor? instance = null;
+
+    private uint32? inhibit_cookie = null;
+
+    private ScreenSaverIface? screensaver_iface = null;
+
+    private bool inhibited = false;
+    private bool simulator_started = false;
+
+    private Inhibitor () {
+        try {
+            screensaver_iface = Bus.get_proxy_sync (BusType.SESSION, IFACE, IFACE_PATH, DBusProxyFlags.NONE);
+        } catch (Error e) {
+            warning ("Could not start screensaver interface: %s", e.message);
+        }
+    }
+
+    public static Inhibitor get_instance () {
+        if (instance == null) {
+            instance = new Inhibitor ();
+        }
+
+        return instance;
+    }
+
+    public void inhibit () {
+        if (screensaver_iface != null && !inhibited) {
+            try {
+                inhibited = true;
+                inhibit_cookie = screensaver_iface.inhibit (
+                    "io.elementary.wingpanel.power-indicator", "io.elementary.wingpanel.power-indicator"
+                );
+                simulate_activity ();
+                debug ("Inhibiting screen");
+            } catch (Error e) {
+                warning ("Could not inhibit screen: %s", e.message);
+            }
+        }
+    }
+
+    public void uninhibit () {
+        if (screensaver_iface != null && inhibited) {
+            try {
+                inhibited = false;
+                screensaver_iface.un_inhibit (inhibit_cookie);
+                debug ("Uninhibiting screen");
+            } catch (Error e) {
+                warning ("Could not uninhibit screen: %s", e.message);
+            }
+        }
+    }
+
+   /*
+    * Inhibit currently does not block a suspend from ocurring,
+    * so we simulate user activity every 2 mins to prevent it
+    */
+    private void simulate_activity () {
+        if (simulator_started) return;
+
+        simulator_started = true;
+        Timeout.add_full (Priority.DEFAULT, 120000, ()=> {
+            if (inhibited) {
+                try {
+                    debug ("Simulating activity");
+                    screensaver_iface.simulate_user_activity ();
+                } catch (Error e) {
+                    warning ("Could not simulate user activity: %s", e.message);
+                }
+            } else {
+                simulator_started = false;
+            }
+
+            return inhibited;
+        });
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ config_in = configure_file(
 
 files = files(
     'Indicator.vala',
+    'Helpers/Inhibitor.vala',
     'Services/AppManager.vala',
     'Services/Backlight/Backlight.vala',
     'Services/DBusInterfaces/Device.vala',


### PR DESCRIPTION
This PR adds a switch to inhibit automatic standby. This can be useful if you only want to temporarily bypass the power settings.

I've been testing this for the past few days and found it extremely helpful when building large software projects on my laptop.

![Screenshot from 2021-01-22 19 01 50](https://user-images.githubusercontent.com/10796736/105527932-9c544780-5ce4-11eb-94dc-6c162eb61e91.png)

Apparently, other people also find such a feature helpful 😁: https://apps.apple.com/app/caffeinated-anti-sleep-app/id1362171212