### PR TITLE
Device: Use prefs system power on AC

### DIFF
--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -229,7 +229,7 @@ public class Power.Services.Device : Object {
 
     public string get_icon_name_for_battery () {
         if (!is_a_battery) {
-            return "battery-ac-adapter";
+            return "preferences-system-power-symbolic";
         }
         if (percentage == 100 && is_charging) {
             return "battery-full-charged";


### PR DESCRIPTION
`battery-ac-adapter` looks weird here on desktop because when this is shown, the things it indicates is the battery level of external devices (that may be wireless). So, proposing something that's power-related but not overly prescriptive

Related to https://github.com/elementary/icons/pull/1014