### PR TITLE
Correct tooltip when no battery

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -192,6 +192,11 @@ public class Power.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
+        if (display_device == null) {
+            display_widget.tooltip_markup = null;
+            return;
+        }
+
         string primary_text;
         string secondary_text;
 
@@ -201,13 +206,19 @@ public class Power.Indicator : Wingpanel.Indicator {
 
         } else {
             primary_text = display_device.device_type.get_name ();
-            secondary_text = _("Using an external power source");
+            secondary_text = null; //Just display the name.
         }
 
-        display_widget.tooltip_markup = "%s\n%s".printf (
-            primary_text,
-            Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (secondary_text)
-        );
+        if (primary_text == null) {
+            display_widget.tooltip_markup = null; //If there is no known display device no useful info can be shown?
+        } else if (secondary_text == null) {
+            display_widget.tooltip_markup = primary_text;
+        } else {
+            display_widget.tooltip_markup = "%s\n%s".printf (
+                primary_text,
+                Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (secondary_text)
+            );
+        }
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -69,6 +69,8 @@ public class Power.Indicator : Wingpanel.Indicator {
 
                     return false;
                 });
+
+                dm.brightness_changed.connect (update_tooltip);
             }
         }
 
@@ -192,25 +194,25 @@ public class Power.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        if (display_device == null) {
-            display_widget.tooltip_markup = null;
-            return;
+        string? primary_text = null;
+        string? secondary_text = null;
+        if (display_device != null) {
+            if (display_device.is_a_battery) {
+                primary_text = _("%s: %s").printf (display_device.device_type.get_name (), display_device.get_info ());
+                secondary_text = _("Middle-click to toggle percentage");
+
+            } else {
+                primary_text = display_device.device_type.get_name ();
+            }
         }
 
-        string primary_text;
-        string secondary_text;
-
-        if (display_device.is_a_battery) {
-            primary_text = _("%s: %s").printf (display_device.device_type.get_name (), display_device.get_info ());
-            secondary_text = _("Middle-click to toggle percentage");
-
-        } else {
-            primary_text = display_device.device_type.get_name ();
-            secondary_text = null; //Just display the name.
+        if (primary_text == null && dm.backlight.present) {
+            primary_text = _("Screen brightness: %i").printf ((int)(dm.brightness));
+            secondary_text = _("Scroll to change screen brightness");
         }
 
         if (primary_text == null) {
-            display_widget.tooltip_markup = null; //If there is no known display device no useful info can be shown?
+            display_widget.tooltip_markup = null;
         } else if (secondary_text == null) {
             display_widget.tooltip_markup = primary_text;
         } else {

--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -86,7 +86,7 @@ public class Power.Services.Device : Object {
                 case PEN:
                     return _("Pen");
                 case LINE_POWER:
-                case UNKNOWN:
+                    return _("Line Power");
                 default:
                     return null;
             }
@@ -268,6 +268,10 @@ public class Power.Services.Device : Object {
 
     public string get_info () {
         var percent = (int)Math.round (percentage);
+
+        if (!is_a_battery) {
+            return "";
+        }
 
         if (percent <= 0) {
             return _("Calculating…");

--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -86,7 +86,7 @@ public class Power.Services.Device : Object {
                 case PEN:
                     return _("Pen");
                 case LINE_POWER:
-                    return _("Line Power");
+                    return _("Plugged In");
                 default:
                     return null;
             }

--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -91,11 +91,21 @@ public class Power.Services.DeviceManager : Object {
             // Add Display Device for Panel display
             var display_device_path = upower.get_display_device ();
             display_device = new Device (display_device_path);
+            /* For some reason line AC power does not appear here */
+            bool display_device_unknown = display_device.device_type.get_name () == null;
 
             // Fetch other devices for Detail in Panel
             var devices = upower.enumerate_devices ();
 
             foreach (ObjectPath device_path in devices) {
+                if (display_device_unknown) {
+                    var tmp_device = new Device (device_path);
+                    if (tmp_device.power_supply) { // Includes Line AC Power
+                        display_device = tmp_device;
+                        display_device_unknown = false;
+                    }
+                }
+
                 if (determine_attached_device (device_path) == true) {
                     register_device (device_path);
                 }

--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -127,35 +127,12 @@ public class Power.Services.DeviceManager : Object {
             // Add Display Device for Panel display
             var display_device_path = upower.get_display_device ();
             display_device = new Device (display_device_path);
-            /* For some reason line AC power does not appear here */
-            bool display_device_unknown = display_device.device_type.get_name () == null;
             // Fetch other devices for Detail in Panel
             var devices = upower.enumerate_devices ();
-            Device? power_supply = null;
-            Device? other_battery = null;
             foreach (ObjectPath device_path in devices) {
-                var tmp_device = new Device (device_path);
-                if (display_device_unknown) {
-                    if (tmp_device.device_type == Device.Type.BATTERY) {
-                        other_battery = tmp_device;
-                    } else if (tmp_device.power_supply) { // Includes Line AC Power
-                        power_supply = tmp_device;
-                    } else if (display_device_unknown) {
-                        display_device = tmp_device;
-                        display_device_unknown = false;
-                    }
-                }
-
                 if (determine_attached_device (device_path) == true) {
                     register_device (device_path);
                 }
-            }
-
-            //Prioritize showing batteries over power supplies
-            if (other_battery != null) {
-                display_device = other_battery;
-            } else if (power_supply != null) {
-                display_device = power_supply;
             }
         } catch (Error e) {
             critical ("Reading UPower devices failed: %s", e.message);

--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -129,14 +129,18 @@ public class Power.Services.DeviceManager : Object {
             display_device = new Device (display_device_path);
             /* For some reason line AC power does not appear here */
             bool display_device_unknown = display_device.device_type.get_name () == null;
-
             // Fetch other devices for Detail in Panel
             var devices = upower.enumerate_devices ();
-
+            Device? power_supply = null;
+            Device? other_battery = null;
             foreach (ObjectPath device_path in devices) {
+                var tmp_device = new Device (device_path);
                 if (display_device_unknown) {
-                    var tmp_device = new Device (device_path);
-                    if (tmp_device.power_supply) { // Includes Line AC Power
+                    if (tmp_device.device_type == Device.Type.BATTERY) {
+                        other_battery = tmp_device;
+                    } else if (tmp_device.power_supply) { // Includes Line AC Power
+                        power_supply = tmp_device;
+                    } else if (display_device_unknown) {
                         display_device = tmp_device;
                         display_device_unknown = false;
                     }
@@ -145,6 +149,13 @@ public class Power.Services.DeviceManager : Object {
                 if (determine_attached_device (device_path) == true) {
                     register_device (device_path);
                 }
+            }
+
+            //Prioritize showing batteries over power supplies
+            if (other_battery != null) {
+                display_device = other_battery;
+            } else if (power_supply != null) {
+                display_device = power_supply;
             }
         } catch (Error e) {
             critical ("Reading UPower devices failed: %s", e.message);
@@ -175,7 +186,6 @@ public class Power.Services.DeviceManager : Object {
     private void update_batteries () {
         batteries = devices.filter ((entry) => {
             var device = entry.value;
-
             return device.is_a_battery;
         });
 


### PR DESCRIPTION
Fixes #172
* Handle failure of `upower.get_display_device ()`
* Search for power supply amongst device list if necessary
* Always connect to change in display_device property
* Modify tooltip accordingly