### PR TITLE
Handle SMOOTH and non-SMOOTH scrolling events 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You'll need the following dependencies:
 * libgtop2-dev
 * libudev-dev
 * libwingpanel-dev
+* libnotify-dev
 * meson
 * valac
 

--- a/po/extra/ru.po
+++ b/po/extra/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-14 20:21+0000\n"
-"PO-Revision-Date: 2021-07-22 13:59+0000\n"
+"PO-Revision-Date: 2021-07-23 14:46+0000\n"
 "Last-Translator: DartDeaDia <jorydit@gmail.com>\n"
 "Language-Team: Russian <https://l10n.elementary.io/projects/wingpanel/"
 "indicator-power-extra/ru/>\n"
@@ -34,19 +34,19 @@ msgstr ""
 
 #: data/power.appdata.xml.in:12
 msgid "New features:"
-msgstr ""
+msgstr "Новые возможности:"
 
 #: data/power.appdata.xml.in:14
 msgid "Show battery statistics when selected"
-msgstr ""
+msgstr "Отображение статистики батареи при выборе"
 
 #: data/power.appdata.xml.in:15
 msgid "Launch apps using power when selected"
-msgstr ""
+msgstr "Запуск приложений с использованием питания, при выборе"
 
 #: data/power.appdata.xml.in:16
 msgid "Control display brightness by scrolling the indicator"
-msgstr ""
+msgstr "Управление яркостью дисплея путем прокрутки колесом мыши по индикатору"
 
 #: data/power.appdata.xml.in:18
 msgid "Minor updates:"
@@ -54,11 +54,11 @@ msgstr "Незначительные обновления:"
 
 #: data/power.appdata.xml.in:20
 msgid "Improvements for desktops with peripherals"
-msgstr ""
+msgstr "Улучшения для настольных компьютеров с периферийными устройствами"
 
 #: data/power.appdata.xml.in:21
 msgid "Filter out internal devices"
-msgstr ""
+msgstr "Фильтрация внутренних устройств"
 
 #: data/power.appdata.xml.in:22
 msgid "Show tooltip on hover"

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -31,6 +31,8 @@ public class Power.Indicator : Wingpanel.Indicator {
     private Services.Device? display_device = null;
     private Services.DeviceManager dm;
 
+    private Notify.Notification? notification;
+
     public Indicator (bool is_in_session) {
         Object (
             code_name : Wingpanel.Indicator.POWER,
@@ -65,6 +67,7 @@ public class Power.Indicator : Wingpanel.Indicator {
                         double change = 0.0;
                         if (handle_scroll_event (e, out change)) {
                             dm.change_brightness ((int)(change * BRIGHTNESS_STEP));
+                            show_notification ();
                             return true;
                         }
                     }
@@ -224,6 +227,20 @@ public class Power.Indicator : Wingpanel.Indicator {
             );
         }
     }
+
+    private bool show_notification () {
+        notification = new Notify.Notification ("indicator-power", "", "display-brightness-symbolic");
+        notification.set_hint ("x-canonical-private-synchronous", new Variant.string ("indicator-power"));
+        notification.set_hint ("value", new Variant.int32 (dm.brightness));
+        try {
+            notification.show ();
+        } catch (Error e) {
+            warning ("Unable to show notification: %s", e.message);
+            notification = null;
+            return false;
+        }
+        return true;
+  }
 }
 
 public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -41,7 +41,9 @@ public class Power.Indicator : Wingpanel.Indicator {
     construct {
         dm = Power.Services.DeviceManager.get_default ();
         var mouse_settings = new GLib.Settings ("org.gnome.desktop.peripherals.mouse");
+        var touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
         mouse_settings.bind ("natural-scroll", this, "natural-scroll-mouse", SettingsBindFlags.DEFAULT);
+        touchpad_settings.bind ("natural-scroll", this, "natural-scroll-touchpad", SettingsBindFlags.DEFAULT);
     }
 
     public override Gtk.Widget get_display_widget () {
@@ -95,7 +97,7 @@ public class Power.Indicator : Wingpanel.Indicator {
         } else if (event_source == Gdk.InputSource.TOUCHPAD) {
             natural_scroll = natural_scroll_touchpad;
         } else {
-            natural_scroll = false;
+            natural_scroll = true;
         }
 
         switch (e.direction) {

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -32,11 +32,11 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
             draw_value = false,
             margin_end = 12,
             hexpand = true,
-            width_request = 175 
+            width_request = 175
         };
-        
+
         brightness_slider.adjustment.page_increment = 10;
-        
+
         brightness_slider.value_changed.connect ((value) => {
             brightness_slider.set_value (value.get_value ());
             dm.brightness = (int) value.get_value ();
@@ -51,6 +51,4 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
         attach (image, 0, 0);
         attach (brightness_slider, 1, 0);
     }
-
-    
 }

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -54,7 +54,6 @@ public class Power.Widgets.ScreenBrightness : Gtk.EventBox {
 
         add (grid);
 
-        //brightness_slider.adjustment.page_increment = 10;
         brightness_slider.set_value (dm.brightness);
 
         brightness_slider.value_changed.connect ((value) => {
@@ -68,7 +67,6 @@ public class Power.Widgets.ScreenBrightness : Gtk.EventBox {
 
         brightness_slider.scroll_event.connect ((e) => {
             /* Re-emit the signal on the eventbox instead of using native handler */
-            //scroll_event (e);
             on_scroll_event (e);
             return true;
         });

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -17,16 +17,23 @@
  * Boston, MA 02110-1301, USA.
  */
 
-public class Power.Widgets.ScreenBrightness : Gtk.Grid {
+public class Power.Widgets.ScreenBrightness : Gtk.EventBox {
+    private const double BRIGHTNESS_STEP = 5;
     private Gtk.Scale brightness_slider;
     private Power.Services.DeviceManager dm;
+    public bool natural_scroll_touchpad { get; set; }
+    public bool natural_scroll_mouse { get; set; }
 
     construct {
         dm = Power.Services.DeviceManager.get_default ();
-        column_spacing = 6;
+        var mouse_settings = new GLib.Settings ("org.gnome.desktop.peripherals.mouse");
+        var touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
+        mouse_settings.bind ("natural-scroll", this, "natural-scroll-mouse", SettingsBindFlags.DEFAULT);
+        touchpad_settings.bind ("natural-scroll", this, "natural-scroll-touchpad", SettingsBindFlags.DEFAULT);
 
-        var image = new Gtk.Image.from_icon_name ("brightness-display-symbolic", Gtk.IconSize.DIALOG);
-        image.margin_start = 6;
+        var image = new Gtk.Image.from_icon_name ("brightness-display-symbolic", Gtk.IconSize.DIALOG) {
+            margin_start = 6
+        };
 
         brightness_slider = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 100, 10) {
             draw_value = false,
@@ -35,7 +42,20 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
             width_request = 175
         };
 
-        brightness_slider.adjustment.page_increment = 10;
+        var grid = new Gtk.Grid () {
+            column_spacing = 6,
+            hexpand = true,
+            margin_start = 6,
+            margin_end = 12
+        };
+
+        grid.add (image);
+        grid.add (brightness_slider);
+
+        add (grid);
+
+        //brightness_slider.adjustment.page_increment = 10;
+        brightness_slider.set_value (dm.brightness);
 
         brightness_slider.value_changed.connect ((value) => {
             brightness_slider.set_value (value.get_value ());
@@ -46,9 +66,85 @@ public class Power.Widgets.ScreenBrightness : Gtk.Grid {
             brightness_slider.set_value ((double)brightness);
         });
 
-        brightness_slider.set_value (dm.brightness);
+        brightness_slider.scroll_event.connect ((e) => {
+            /* Re-emit the signal on the eventbox instead of using native handler */
+            //scroll_event (e);
+            on_scroll_event (e);
+            return true;
+        });
 
-        attach (image, 0, 0);
-        attach (brightness_slider, 1, 0);
     }
+
+    private bool on_scroll_event (Gdk.EventScroll e) {
+      double change = 0.0;
+      if (handle_scroll_event (e, out change)) {
+          dm.change_brightness ((int)(change * BRIGHTNESS_STEP));
+          return true;
+      }
+      return false;
+    }
+
+    /* Handles both SMOOTH and non-SMOOTH events.
+     * * accumulates very small changes until they become significant.
+     * * ignores rapid changes in direction.
+     * * responds to both horizontal and vertical scrolling.
+     * In the case of diagonal scrolling, it ignores the event unless movement in one direction
+     * is more than twice the movement in the other direction.
+     */
+    private double total_y_delta= 0;
+    private double total_x_delta= 0;
+    private bool handle_scroll_event (Gdk.EventScroll e, out double change) {
+        change = 0.0;
+        bool natural_scroll;
+        var event_source = e.get_source_device ().input_source;
+        if (event_source == Gdk.InputSource.MOUSE) {
+            natural_scroll = natural_scroll_mouse;
+        } else if (event_source == Gdk.InputSource.TOUCHPAD) {
+            natural_scroll = natural_scroll_touchpad;
+        } else {
+            natural_scroll = true;
+        }
+
+        switch (e.direction) {
+            case Gdk.ScrollDirection.SMOOTH:
+                var abs_x = double.max (e.delta_x.abs (), 0.0001);
+                var abs_y = double.max (e.delta_y.abs (), 0.0001);
+
+                if (abs_y / abs_x > 2.0) {
+                    total_y_delta += e.delta_y;
+                } else if (abs_x / abs_y > 2.0) {
+                    total_x_delta += e.delta_x;
+                }
+                break;
+            case Gdk.ScrollDirection.UP:
+                total_y_delta = -1.0;
+                break;
+            case Gdk.ScrollDirection.DOWN:
+                total_y_delta = 1.0;
+                break;
+            case Gdk.ScrollDirection.LEFT:
+                total_x_delta = -1.0;
+                break;
+            case Gdk.ScrollDirection.RIGHT:
+                total_x_delta = 1.0;
+                break;
+            default:
+                break;
+        }
+
+        if (total_y_delta.abs () > 0.5) {
+            change = natural_scroll ? total_y_delta : -total_y_delta;
+        } else if (total_x_delta.abs () > 0.5) {
+            change = natural_scroll ? -total_x_delta : total_x_delta;
+        }
+
+        if (change.abs () > 0.0) {
+            total_y_delta = 0.0;
+            total_x_delta = 0.0;
+            return true;
+        }
+
+        return false;
+    }
+    
 }

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -146,5 +146,4 @@ public class Power.Widgets.ScreenBrightness : Gtk.EventBox {
 
         return false;
     }
-    
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,6 +38,7 @@ dependencies = [
     dependency('libbamf3'),
     dependency('libgtop-2.0'),
     dependency('libudev'),
+    dependency('libnotify'),
     meson.get_compiler('vala').find_library('posix'),
     wingpanel_dep
 ]


### PR DESCRIPTION
fixes #189 
## Aditional: 
- Show notification in Icon scrolling (like audio indicator does)
![Screenshot from 2021-07-24 13-09-18](https://user-images.githubusercontent.com/22928302/126877562-25da5160-d1b8-45c6-abe2-0110cdd335cd.png)

- Handles both SMOOTH and non-SMOOTH events.
- accumulates very small changes until they become significant.
- ignores rapid changes in direction.
- responds to both horizontal and vertical scrolling.
- In the case of diagonal scrolling, it ignores the event unless movement in one direction
- is more than twice the movement in the other direction.