### PR TITLE
Improve scale brightness changes with scroll events on touchpads

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -70,7 +70,7 @@ public class Power.Indicator : Wingpanel.Indicator {
                     if (e.direction != Gdk.ScrollDirection.LEFT && e.direction != Gdk.ScrollDirection.RIGHT) {
                         double change = 0.0;
                         if (handle_scroll_event (e, out change)) {
-                            dm.change_brightness ((int)(change * BRIGHTNESS_STEP));
+                            dm.change_brightness ((int) (Math.round (change) * BRIGHTNESS_STEP));
                             if (!popover_widget.is_visible ()) {
                               show_notification ();
                             }

--- a/src/Widgets/ScreenBrightness.vala
+++ b/src/Widgets/ScreenBrightness.vala
@@ -78,7 +78,7 @@ public class Power.Widgets.ScreenBrightness : Gtk.EventBox {
     private bool on_scroll_event (Gdk.EventScroll e) {
         double change = 0.0;
         if (handle_scroll_event (e, out change)) {
-            dm.change_brightness ((int)(change * BRIGHTNESS_STEP));
+            dm.change_brightness ((int) (Math.round (change) * BRIGHTNESS_STEP));
             return true;
         }
         return false;


### PR DESCRIPTION
Currently the scale has glitches when the user make fast movements with touchpad. 

This change fix and normalize behavior with mouse or touchpad. 

## Before

https://user-images.githubusercontent.com/22928302/128289284-c06effdd-98c6-4a54-896a-0086715c1838.mp4


## After

https://user-images.githubusercontent.com/22928302/128289067-414edf56-99a8-4a42-a4e7-4224da7da9af.mp4

