### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -42,6 +42,9 @@ public class Power.Indicator : Wingpanel.Indicator {
     }
 
     construct {
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+
         dm = Power.Services.DeviceManager.get_default ();
         var mouse_settings = new GLib.Settings ("org.gnome.desktop.peripherals.mouse");
         mouse_settings.bind ("natural-scroll", this, "natural-scroll-mouse", SettingsBindFlags.DEFAULT);

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,3 +1,4 @@
 namespace Constants {
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', 
 
 conf_data = configuration_data()
 conf_data.set('GETTEXT_PACKAGE', gettext_name)
+conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 
 config_in = configure_file(
     input: 'config.vala.in',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)