### PR TITLE
AppList: Don't add the header as a row

### DIFF
--- a/src/Widgets/AppList.vala
+++ b/src/Widgets/AppList.vala
@@ -61,7 +61,11 @@ public class Power.Widgets.AppList : Gtk.ListBox {
 
         if (eaters.size > 0) {
             var title_label = new Granite.HeaderLabel (_("Apps Using Lots of Power"));
-            add (title_label);
+            set_header_func ((row, before) => {
+                if (row.get_index () == 0) {
+                    row.set_header (title_label);
+                }
+            });
         }
 
         eaters.@foreach ((power_eater) => {


### PR DESCRIPTION
Fixes #224

Adding the "Apps Using Lots of Power" as a header label of the AppList, not as a row of AppList.