### PR TITLE
AppList: Don't show the power eater section if failed to get the app

### DIFF
--- a/src/Widgets/AppList.vala
+++ b/src/Widgets/AppList.vala
@@ -58,24 +58,27 @@ public class Power.Widgets.AppList : Gtk.ListBox {
 
     private void update_list () {
         var eaters = app_manager.get_top_power_eaters (12);
-
-        if (eaters.size > 0) {
-            var title_label = new Granite.HeaderLabel (_("Apps Using Lots of Power"));
-            add (title_label);
-        }
-
         eaters.@foreach ((power_eater) => {
-            var desktop_app_info = new DesktopAppInfo.from_filename (power_eater.application.get_desktop_file ());
-
-            if (desktop_app_info == null) {
+            var power_eater_desktop_file = power_eater.application.get_desktop_file ();
+            if (power_eater_desktop_file == null) {
                 return false;
             }
 
+            var desktop_app_info = new DesktopAppInfo.from_filename (power_eater_desktop_file);
             var app_row = new AppRow (desktop_app_info);
             add (app_row);
 
             return true;
         });
+
+        if (get_row_at_index (0) != null) {
+            var title_label = new Granite.HeaderLabel (_("Apps Using Lots of Power"));
+            set_header_func ((row, before) => {
+                if (row.get_index () == 0) {
+                    row.set_header (title_label);
+                }
+            });
+        }
 
         show_all ();
     }
@@ -106,7 +109,7 @@ public class Power.Widgets.AppList : Gtk.ListBox {
             }
 
             var app_name = app_info.get_name ();
-            if (app_name != null) {
+            if (app_name != null || app_name != "") {
                 app_name_label.label = app_name;
             }
 

--- a/src/Widgets/AppList.vala
+++ b/src/Widgets/AppList.vala
@@ -109,7 +109,7 @@ public class Power.Widgets.AppList : Gtk.ListBox {
             }
 
             var app_name = app_info.get_name ();
-            if (app_name != null || app_name != "") {
+            if (app_name != null) {
                 app_name_label.label = app_name;
             }
 

--- a/src/Widgets/AppList.vala
+++ b/src/Widgets/AppList.vala
@@ -71,6 +71,7 @@ public class Power.Widgets.AppList : Gtk.ListBox {
             return true;
         });
 
+        // Add the header label if we acually have row(s)
         if (get_row_at_index (0) != null) {
             var title_label = new Granite.HeaderLabel (_("Apps Using Lots of Power"));
             set_header_func ((row, before) => {


### PR DESCRIPTION
**Merge #225 first!**

It seems like `power_eater.application.get_desktop_file ()` can return `null` if the desktop file is unavailable. For me, this happens when running several virtual machines on VirtualBox. And in this case (when the desktop file is unavailable), the power eater section in the Power Indicator only shows the header and blank rows:

![Screenshot from 2022-03-09 09-36-53](https://user-images.githubusercontent.com/26003928/157350709-ff178201-40a2-401d-be46-551217c1f6ad.png)

This PR fixes this strange behavior. If the desktop file is unavailable and can't show any apps, simply hide the header itself too, by counting the actual number of the AppRows, instead of the number of the power eaters (which could include apps whose desktop file is available).