### PR TITLE
Indicator: send notification for low power

### DIFF
--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -163,7 +163,7 @@ public class Power.Services.Device : Object {
 
         if (connect_to_bus ()) {
             update_properties ();
-            connect_signals ();
+            device.g_properties_changed.connect (update_properties);
         }
     }
 
@@ -177,10 +177,6 @@ public class Power.Services.Device : Object {
         }
 
         return device != null;
-    }
-
-    private void connect_signals () {
-        device.g_properties_changed.connect (update_properties);
     }
 
     private void update_properties () {
@@ -296,7 +292,7 @@ public class Power.Services.Device : Object {
             info += _("%i%% charged").printf (percent);
 
             if (time_to_full > 0) {
-                info += " - ";
+                info += " — ";
                 if (time_to_full >= 86400) {
                     var days = time_to_full / 86400;
                     info += dngettext (
@@ -334,7 +330,7 @@ public class Power.Services.Device : Object {
             info += _("%i%% remaining").printf (percent);
 
             if (time_to_empty > 0) {
-                info += " - ";
+                info += " — ";
                 if (time_to_empty >= 86400) {
                     var days = time_to_empty / 86400;
                     info += dngettext (


### PR DESCRIPTION
Todo:
- [ ] Fix icons for notifications sent from Notify in elementary/notifications
- [ ] Send notifications for peripherals
- [ ] Block GNOME Power manager so we don't get duplicates