### PR TITLE
appdata: move <issues> out of <description> to make AppData valid again

### DIFF
--- a/data/power.appdata.xml.in
+++ b/data/power.appdata.xml.in
@@ -18,11 +18,11 @@
           <li>Do a better job hiding the brightness slider on unsupported displays</li>
           <li>Updated translations</li>
         </ul>
-        <issues>
-          <issue url="https://github.com/elementary/wingpanel-indicator-power/issues/224">Clicking the "Apps Using Lots of Power" header label causes a crash</issue>
-          <issue url="https://github.com/elementary/wingpanel-indicator-power/pull/226">Don't show the power eater section if failed to get app info</issue>
-        </issues>
       </description>
+      <issues>
+        <issue url="https://github.com/elementary/wingpanel-indicator-power/issues/224">Clicking the "Apps Using Lots of Power" header label causes a crash</issue>
+        <issue url="https://github.com/elementary/wingpanel-indicator-power/pull/226">Don't show the power eater section if failed to get app info</issue>
+      </issues>
     </release>
 
     <release version="6.1.0" date="2021-08-23" urgency="medium">


### PR DESCRIPTION
It looks like for the last release, the `<issues>` were added inside the `<description>` tag, making the AppData invalid. I looked at other elementary projects' AppData files, and it looks like the `<issues>` list should just be moved outside the `<description>`.