### PR TITLE
Future: Don't call Refresh() on UPower.Device

### DIFF
--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -184,12 +184,6 @@ public class Power.Services.Device : Object {
     }
 
     private void update_properties () {
-        try {
-            device.refresh ();
-        } catch (Error e) {
-            critical ("Updating the upower device parameters failed: %s", e.message);
-        }
-
         has_history = device.has_history;
         has_statistics = device.has_statistics;
         is_present = device.is_present;


### PR DESCRIPTION
This method no longer works as of UPower 0.99.17, and simply spams the system log with warnings. It is apparently not necessary to call it.

I'm not sure whether UPower 0.99.17 will ever hit Ubuntu 22.04, but it is already part of Ubuntu 22.10, and is causing this error. Merging this now shouldn't cause any issues. (Works on my machine, as they say)

https://gitlab.freedesktop.org/upower/upower/-/commit/d0ebbe32bb5cec06335a7bd0f11f8550deaec16e