### PR TITLE
Dont propagate scroll even if the delta is 0

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -64,6 +64,6 @@ public class Power.Utils {
                 .change_brightness ((int) Math.round (dir * BRIGHTNESS_STEP));
         }
 
-        return true;
+        return Gdk.EVENT_STOP;
     }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -12,7 +12,6 @@ public class Power.Utils {
         bool natural_scroll;
         var event_source_device = e.get_source_device ();
         if (event_source_device == null) {
-            warning ("NO DEVIC");
             return false;
         }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -12,6 +12,7 @@ public class Power.Utils {
         bool natural_scroll;
         var event_source_device = e.get_source_device ();
         if (event_source_device == null) {
+            warning ("NO DEVIC");
             return false;
         }
 
@@ -62,9 +63,8 @@ public class Power.Utils {
             total_x_delta = 0.0;
             Power.Services.DeviceManager.get_default ()
                 .change_brightness ((int) Math.round (dir * BRIGHTNESS_STEP));
-            return true;
-        } else {
-            return false;
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
Sometimes scroll gets emitted with a 0 delta. In this case we still don't want to propagate because we are usually consuming events before and after the 0 one. Noticeable when scrolling to switch workspaces is active.