### PR TITLE
Show the device model if available

### DIFF
--- a/src/Widgets/DeviceRow.vala
+++ b/src/Widgets/DeviceRow.vala
@@ -105,12 +105,12 @@ public class Power.Widgets.DeviceRow : Gtk.ListBoxRow {
         }
 
         if (type_string == null) {
-            if (battery.vendor != null && battery.vendor.strip () != "") {
-                type_string = "%s %s".printf (battery.vendor, _("Device"));
-            }
-
-            if (battery.model != null && battery.model.strip () != "") {
+            if (battery.vendor != null && battery.vendor.strip() != "") {
+                type_string = "%s %s".printf(battery.vendor, _("Device"));
+            } else if (battery.model != null && battery.model.strip() != "") {
                 type_string = battery.model;
+            } else {
+                type_string = _("Device");
             }
         }
 

--- a/src/Widgets/DeviceRow.vala
+++ b/src/Widgets/DeviceRow.vala
@@ -105,7 +105,13 @@ public class Power.Widgets.DeviceRow : Gtk.ListBoxRow {
         }
 
         if (type_string == null) {
-            type_string = "%s %s".printf (battery.vendor, _("Device"));
+            if (battery.vendor != null && battery.vendor.strip () != "") {
+                type_string = "%s %s".printf (battery.vendor, _("Device"));
+            }
+
+            if (battery.model != null && battery.model.strip () != "") {
+                type_string = battery.model;
+            }
         }
 
         return "<b>%s</b>".printf (type_string);

--- a/src/Widgets/DeviceRow.vala
+++ b/src/Widgets/DeviceRow.vala
@@ -105,9 +105,9 @@ public class Power.Widgets.DeviceRow : Gtk.ListBoxRow {
         }
 
         if (type_string == null) {
-            if (battery.vendor != null && battery.vendor.strip() != "") {
-                type_string = "%s %s".printf(battery.vendor, _("Device"));
-            } else if (battery.model != null && battery.model.strip() != "") {
+            if (battery.vendor != null && battery.vendor.strip () != "") {
+                type_string = "%s %s".printf (battery.vendor, _("Device"));
+            } else if (battery.model != null && battery.model.strip () != "") {
                 type_string = battery.model;
             } else {
                 type_string = _("Device");


### PR DESCRIPTION
Fixed: #274

- Displays device `model` if available
- Fixes spacing when `vendor` property is not available

![image](https://github.com/user-attachments/assets/fb77e995-c8a3-4cf2-b261-1bdceeb2c770)
