### PR TITLE
PowerModeList: Require settings, use action

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,9 +96,7 @@ public class Power.Indicator : Wingpanel.Indicator {
         return popover_widget;
     }
 
-    public override void opened () {
-        popover_widget.update_power_mode ();
-    }
+    public override void opened () { }
 
     public override void closed () {
 

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -144,8 +144,4 @@ public class Power.Widgets.PopoverWidget : Gtk.Grid {
     private void update_device_separator_revealer () {
         device_separator_revealer.reveal_child = dm.backlight.present && dm.has_battery;
     }
-
-    public void update_power_mode () {
-        power_mode_list?.update_active_profile ();
-    }
 }

--- a/src/Widgets/PowerModeList.vala
+++ b/src/Widgets/PowerModeList.vala
@@ -4,25 +4,26 @@
  */
 
 public class Power.Widgets.PowerModeList : Gtk.Box {
+    private const string ACTION_GROUP_PREFIX = "power-mode-list";
+    private const string ACTION_PREFIX = ACTION_GROUP_PREFIX + ".";
+    private const string ACTION_PLUGGED_IN = "profile-plugged-in";
+    private const string ACTION_ON_BATTERY = "profile-on-good-battery";
+
     public static bool successfully_initialized { get; private set; default = true; }
 
     private static Services.DBusInterfaces.PowerProfile? pprofile;
     private static Services.DeviceManager device_manager;
     private static GLib.Settings? settings;
 
-    private string settings_key;
-    private Gtk.RadioButton saver_radio;
-    private Gtk.RadioButton balanced_radio;
-    private Gtk.RadioButton performance_radio;
-
-    class construct {
+    static construct {
         device_manager = Services.DeviceManager.get_default ();
 
         var schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.settings-daemon.power", true);
         if (schema != null && schema.has_key ("profile-plugged-in") && schema.has_key ("profile-on-good-battery")) {
             settings = new GLib.Settings ("io.elementary.settings-daemon.power");
         } else {
-            warning ("settings-daemon schema not found, will connect to power-profiles-daemon directly");
+            warning ("settings-daemon schema not found, power mode setting not available");
+            successfully_initialized = false;
         }
 
         // Connect always to know which profiles are available on the system
@@ -39,10 +40,23 @@ public class Power.Widgets.PowerModeList : Gtk.Box {
         }
     }
 
+    private PowerModeCheck saver_radio;
+    private PowerModeCheck balanced_radio;
+    private PowerModeCheck performance_radio;
+
     construct {
-        if (pprofile == null) {
+        if (pprofile == null || settings == null) {
             return;
         }
+
+        var action_plugged_in = settings.create_action (ACTION_PLUGGED_IN);
+        var action_on_battery = settings.create_action (ACTION_ON_BATTERY);
+
+        var action_group = new SimpleActionGroup ();
+        action_group.add_action (action_plugged_in);
+        action_group.add_action (action_on_battery);
+
+        insert_action_group (ACTION_GROUP_PREFIX, action_group);
 
         orientation = VERTICAL;
         margin_start = 6;
@@ -50,15 +64,9 @@ public class Power.Widgets.PowerModeList : Gtk.Box {
         margin_bottom = 6;
         margin_end = 6;
 
-        saver_radio = new PowerModeCheck ("power-mode-powersaver-symbolic", _("Power Saver"));
-
-        balanced_radio = new PowerModeCheck ("power-mode-balanced-symbolic", _("Balanced")) {
-            group = saver_radio
-        };
-
-        performance_radio = new PowerModeCheck ("power-mode-performance-symbolic", _("Performance")) {
-            group = saver_radio
-        };
+        saver_radio = new PowerModeCheck ("power-mode-powersaver-symbolic", _("Power Saver"), "power-saver");
+        balanced_radio = new PowerModeCheck ("power-mode-balanced-symbolic", _("Balanced"), "balanced");
+        performance_radio = new PowerModeCheck ("power-mode-performance-symbolic", _("Performance"), "performance");
 
         foreach (unowned var profile in pprofile.profiles) {
             switch (profile.get ("Profile").get_string ()) {
@@ -75,82 +83,26 @@ public class Power.Widgets.PowerModeList : Gtk.Box {
         }
 
         update_on_battery_state ();
-        device_manager.notify["on-battery"].connect (() => {
-            update_on_battery_state ();
-        });
-
-        saver_radio.toggled.connect (() => {
-            if (saver_radio.active) {
-                if (settings != null) {
-                    settings.set_string (settings_key, "power-saver");
-                } else {
-                    pprofile.active_profile = "power-saver";
-                }
-            }
-        });
-
-        balanced_radio.toggled.connect (() => {
-            if (balanced_radio.active) {
-                if (settings != null) {
-                    settings.set_string (settings_key, "balanced");
-                } else {
-                    pprofile.active_profile = "balanced";
-                }
-            }
-        });
-
-        performance_radio.toggled.connect (() => {
-            if (performance_radio.active) {
-                if (settings != null) {
-                    settings.set_string (settings_key, "performance");
-                } else {
-                    pprofile.active_profile = "performance";
-                }
-            }
-        });
+        device_manager.notify["on-battery"].connect (update_on_battery_state);
     }
 
     private void update_on_battery_state () {
-        settings_key = device_manager.on_battery ? "profile-on-good-battery" : "profile-plugged-in";
-        update_active_profile ();
-    }
-
-    public void update_active_profile () {
-        if (settings != null) {
-            switch (settings.get_string (settings_key)) {
-                case "power-saver":
-                    saver_radio.active = true;
-                    break;
-                case "balanced":
-                    balanced_radio.active = true;
-                    break;
-                case "performance":
-                    performance_radio.active = true;
-                    break;
-            }
-        } else {
-            switch (pprofile.active_profile) {
-                case "power-saver":
-                    saver_radio.active = true;
-                    break;
-                case "balanced":
-                    balanced_radio.active = true;
-                    break;
-                case "performance":
-                    performance_radio.active = true;
-                    break;
-            }
-        }
+        var action = ACTION_PREFIX + (device_manager.on_battery ? ACTION_ON_BATTERY : ACTION_PLUGGED_IN);
+        saver_radio.action_name = action;
+        balanced_radio.action_name = action;
+        performance_radio.action_name = action;
     }
 
     private class PowerModeCheck : Gtk.RadioButton {
         public string icon_name { get; construct; }
         public new string label { get; construct; }
+        public string profile { get; construct; }
 
-        public PowerModeCheck (string icon_name, string label) {
+        public PowerModeCheck (string icon_name, string label, string profile) {
             Object (
                 icon_name: icon_name,
-                label: label
+                label: label,
+                profile: profile
             );
         }
 
@@ -171,6 +123,7 @@ public class Power.Widgets.PowerModeList : Gtk.Box {
             box.add (label_widget);
 
             child = box;
+            action_target = profile;
 
             get_style_context ().add_class ("image-button");
         }


### PR DESCRIPTION
We now require the settings-daemon for power mode setting.

Simplify and use Settings.create_action.

This is GTK4 prep.