### PR TITLE
Update RDNN to io.elementary.panel.power

### DIFF
--- a/data/icons.gresource.xml
+++ b/data/icons.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/io/elementary/desktop/wingpanel/power">
+  <gresource prefix="/io/elementary/panel/power">
     <file alias="scalable/categories/power-mode-balanced-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/balanced.svg</file>
     <file alias="scalable/categories/power-mode-performance-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/performance.svg</file>
     <file alias="scalable/categories/power-mode-powersaver-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/powersaver.svg</file>

--- a/data/power.gschema.xml
+++ b/data/power.gschema.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-	<schema path="/io/elementary/panel/power/" id="io.elementary.panel.power">
-		<key type="b" name="show-percentage">
-			<default>false</default>
-			<summary>Sets if the percentage of the primary battery is shown in the panel.</summary>
-			<description>Enable this to see the percentage of the battery directly in the panel without having to click onto the power-indicator.</description>
-		</key>
-	</schema>
+  <schema path="/io/elementary/panel/power/" id="io.elementary.panel.power">
+    <key type="b" name="show-percentage">
+      <default>false</default>
+      <summary>Sets if the percentage of the primary battery is shown in the panel.</summary>
+      <description>Enable this to see the percentage of the battery directly in the panel without having to click onto the power-indicator.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -43,7 +43,7 @@ public class Power.Indicator : Wingpanel.Indicator {
     construct {
         GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
         GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
-        Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).add_resource_path ("/io/elementary/desktop/wingpanel/power");
+        Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).add_resource_path ("/io/elementary/panel/power");
 
         dm = Power.Services.DeviceManager.get_default ();
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -18,7 +18,7 @@
  */
 
 public class Power.Widgets.DisplayWidget : Gtk.Box {
-    private static Settings settings = new GLib.Settings ("io.elementary.desktop.wingpanel.power");
+    private static Settings settings = new GLib.Settings ("io.elementary.panel.power");
 
     private Gtk.Revealer percent_revealer;
     public string icon_name {

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -35,7 +35,7 @@ public class Power.Widgets.PopoverWidget : Gtk.Box {
     }
 
     construct {
-        var settings = new GLib.Settings ("io.elementary.desktop.wingpanel.power");
+        var settings = new GLib.Settings ("io.elementary.panel.power");
 
         var device_list = new DeviceList ();
 


### PR DESCRIPTION
We switched RDNN from `io.elementary.desktop.wingpanel.power` to `io.elementary.panel.power` in #285 but there are some leftovers. This PR corrects them and plus make sure to use spaces instead of tabs for indentation in the gschema file while I'm here.
